### PR TITLE
feature: add `MessageOps::set_data` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"

--- a/src/encrypted/command.rs
+++ b/src/encrypted/command.rs
@@ -76,7 +76,7 @@ impl EncryptedCommand {
     /// encrypted message is wrapped in an outer standard SSP message.
     ///
     /// Matryoshka dolls all the way down...
-    pub fn set_message_data<M: CommandOps>(&mut self, message: &mut M) -> Result<()> {
+    pub fn set_message_data(&mut self, message: &mut dyn CommandOps) -> Result<()> {
         let len = message.data_len();
 
         if message.data().len() != len {

--- a/src/message.rs
+++ b/src/message.rs
@@ -139,6 +139,25 @@ pub trait MessageOps {
         self.buf_mut()[start..end].as_mut()
     }
 
+    fn set_data(&mut self, data: &[u8]) -> Result<()> {
+        let len = data.len();
+        let max_len = self.buf().len() - self.metadata_len();
+
+        if self.is_variable() {
+            if !(1..=max_len).contains(&len) {
+                return Err(Error::InvalidDataLength((len, max_len)));
+            }
+
+            self.set_data_len(len as u8);
+        } else if len != self.data_len() {
+            return Err(Error::InvalidDataLength((len, self.data_len())));
+        }
+
+        self.data_mut().copy_from_slice(data);
+
+        Ok(())
+    }
+
     /// Toggles the value of the [SequenceFlag](crate::SequenceFlag).
     fn toggle_sequence_flag(&mut self) {
         let mut seq_id = SequenceId::from(self.buf()[index::SEQ_ID]);

--- a/src/message/variant.rs
+++ b/src/message/variant.rs
@@ -49,8 +49,82 @@ pub enum MessageVariant {
 }
 
 impl MessageVariant {
+    pub fn new(msg_type: MessageType) -> Self {
+        match msg_type {
+            MessageType::SetInhibits => Self::SetInhibitsResponse(SetInhibitsResponse::new()),
+            MessageType::ChannelValueData => Self::ChannelValueDataResponse(ChannelValueDataResponse::new()),
+            MessageType::ConfigureBezel => Self::ConfigureBezelResponse(ConfigureBezelResponse::new()),
+            MessageType::Disable => Self::DisableResponse(DisableResponse::new()),
+            MessageType::DisplayOff => Self::DisplayOffResponse(DisplayOffResponse::new()),
+            MessageType::DisplayOn => Self::DisplayOnResponse(DisplayOnResponse::new()),
+            MessageType::Empty => Self::EmptyResponse(EmptyResponse::new()),
+            MessageType::EncryptionReset => Self::EncryptionResetResponse(EncryptionResetResponse::new()),
+            MessageType::Enable => Self::EnableResponse(EnableResponse::new()),
+            MessageType::EventAck => Self::EventAckResponse(EventAckResponse::new()),
+            MessageType::GetBarcodeData => Self::GetBarcodeDataResponse(GetBarcodeDataResponse::new()),
+            MessageType::GetBarcodeInhibit => Self::GetBarcodeInhibitResponse(GetBarcodeInhibitResponse::new()),
+            MessageType::GetBarcodeReaderConfiguration => Self::GetBarcodeReaderConfigurationResponse(GetBarcodeReaderConfigurationResponse::new()),
+            MessageType::SetBarcodeInhibit => Self::SetBarcodeInhibitResponse(SetBarcodeInhibitResponse::new()),
+            MessageType::SetBarcodeReaderConfiguration => Self::SetBarcodeReaderConfigurationResponse(SetBarcodeReaderConfigurationResponse::new()),
+            MessageType::Hold => Self::HoldResponse(HoldResponse::new()),
+            MessageType::HostProtocolVersion => Self::HostProtocolVersionResponse(HostProtocolVersionResponse::new()),
+            MessageType::LastRejectCode => Self::LastRejectCodeResponse(LastRejectCodeResponse::new()),
+            MessageType::Poll => Self::PollResponse(PollResponse::new()),
+            MessageType::PollWithAck => Self::PollWithAckResponse(PollWithAckResponse::new()),
+            MessageType::Reject => Self::RejectResponse(RejectResponse::new()),
+            MessageType::SerialNumber => Self::SerialNumberResponse(SerialNumberResponse::new()),
+            MessageType::SetEncryptionKey => Self::SetEncryptionKeyResponse(SetEncryptionKeyResponse::new()),
+            MessageType::SetGenerator => Self::SetGeneratorResponse(SetGeneratorResponse::new()),
+            MessageType::SetModulus => Self::SetModulusResponse(SetModulusResponse::new()),
+            MessageType::RequestKeyExchange => Self::RequestKeyExchangeResponse(RequestKeyExchangeResponse::new()),
+            MessageType::SetupRequest => Self::SetupRequestResponse(SetupRequestResponse::new()),
+            MessageType::SmartEmpty => Self::SmartEmptyResponse(SmartEmptyResponse::new()),
+            MessageType::Synchronisation => Self::SyncResponse(SyncResponse::new()),
+            MessageType::UnitData => Self::UnitDataResponse(UnitDataResponse::new()),
+            MessageType::Encrypted => Self::WrappedEncryptedMessage(WrappedEncryptedMessage::new()),
+            _ => Self::PollResponse(PollResponse::new()),
+        }
+    }
+
     /// Gets a reference to the [MessageVariant] as a generic response.
     pub fn as_response(&self) -> &dyn ResponseOps {
+        match self {
+            Self::SetInhibitsResponse(msg) => msg,
+            Self::ChannelValueDataResponse(msg) => msg,
+            Self::ConfigureBezelResponse(msg) => msg,
+            Self::DisableResponse(msg) => msg,
+            Self::DisplayOffResponse(msg) => msg,
+            Self::DisplayOnResponse(msg) => msg,
+            Self::EmptyResponse(msg) => msg,
+            Self::EnableResponse(msg) => msg,
+            Self::EncryptionResetResponse(msg) => msg,
+            Self::EventAckResponse(msg) => msg,
+            Self::GetBarcodeDataResponse(msg) => msg,
+            Self::GetBarcodeInhibitResponse(msg) => msg,
+            Self::GetBarcodeReaderConfigurationResponse(msg) => msg,
+            Self::SetBarcodeInhibitResponse(msg) => msg,
+            Self::SetBarcodeReaderConfigurationResponse(msg) => msg,
+            Self::HoldResponse(msg) => msg,
+            Self::HostProtocolVersionResponse(msg) => msg,
+            Self::LastRejectCodeResponse(msg) => msg,
+            Self::PollResponse(msg) => msg,
+            Self::PollWithAckResponse(msg) => msg,
+            Self::RejectResponse(msg) => msg,
+            Self::SerialNumberResponse(msg) => msg,
+            Self::SetEncryptionKeyResponse(msg) => msg,
+            Self::SetGeneratorResponse(msg) => msg,
+            Self::SetModulusResponse(msg) => msg,
+            Self::RequestKeyExchangeResponse(msg) => msg,
+            Self::SetupRequestResponse(msg) => msg,
+            Self::SmartEmptyResponse(msg) => msg,
+            Self::SyncResponse(msg) => msg,
+            Self::UnitDataResponse(msg) => msg,
+            Self::WrappedEncryptedMessage(msg) => msg,
+        }
+    }
+
+    /// Gets a mutable reference to the [MessageVariant] as a generic response.
+    pub fn as_response_mut(&mut self) -> &mut dyn ResponseOps {
         match self {
             Self::SetInhibitsResponse(msg) => msg,
             Self::ChannelValueDataResponse(msg) => msg,


### PR DESCRIPTION
Adds a `set_data` convenience function to the `MessageOps` trait for setting message data.

The function performs basic sanity checks on the input data, and if all tests pass, sets the data field in the message buffer.

For variable-length messages, also sets the length message field.