### PR TITLE
update: use crates.io version of smol-jsonrpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ optional = true
 
 [dependencies.smol-jsonrpc]
 version = "0.1"
-git = "https://gitlab.com/smol-jsonrpc/smol-jsonrpc"
 optional = true
 
 [features]


### PR DESCRIPTION
Changes the dependency from git to the crates.io version.