### PR TITLE
device_status: add `AtomicDeviceStatus`

### DIFF
--- a/src/types/device_status.rs
+++ b/src/types/device_status.rs
@@ -1,3 +1,5 @@
+use crate::std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
+
 use crate::{
     impl_default, std::fmt, ResponseOps, SetupRequestResponse, UnitDataResponse, CLOSE_BRACE,
     OPEN_BRACE,
@@ -17,9 +19,11 @@ pub struct DeviceStatus {
     country_code: CountryCode,
     value_multiplier: ValueMultiplier,
     protocol_version: ProtocolVersion,
+    cashbox_attached: bool,
 }
 
 impl DeviceStatus {
+    /// Creates a new [DeviceStatus].
     pub const fn new() -> Self {
         Self {
             status: ResponseStatus::Ok,
@@ -28,6 +32,7 @@ impl DeviceStatus {
             country_code: CountryCode::from_inner(0),
             value_multiplier: ValueMultiplier::from_inner(0),
             protocol_version: ProtocolVersion::Reserved,
+            cashbox_attached: false,
         }
     }
 
@@ -36,9 +41,30 @@ impl DeviceStatus {
         self.status
     }
 
+    pub fn set_response_status(&mut self, status: ResponseStatus) {
+        self.status = status;
+    }
+
+    /// Builder function that sets the [ResponseStatus].
+    pub fn with_response_status(mut self, status: ResponseStatus) -> Self {
+        self.set_response_status(status);
+        self
+    }
+
     /// Gets the [UnitType].
     pub const fn unit_type(&self) -> UnitType {
         self.unit_type
+    }
+
+    /// Sets the [UnitType].
+    pub fn set_unit_type(&mut self, unit_type: UnitType) {
+        self.unit_type = unit_type;
+    }
+
+    /// Builder function that sets the [UnitType].
+    pub fn with_unit_type(mut self, unit_type: UnitType) -> Self {
+        self.set_unit_type(unit_type);
+        self
     }
 
     /// Gets the [FirmwareVersion].
@@ -46,9 +72,31 @@ impl DeviceStatus {
         self.firmware_version
     }
 
+    /// Sets the [FirmwareVersion].
+    pub fn set_firmware_version(&mut self, firmware_version: FirmwareVersion) {
+        self.firmware_version = firmware_version;
+    }
+
+    /// Builder function that sets the [FirmwareVersion].
+    pub fn with_firmware_version(mut self, firmware_version: FirmwareVersion) -> Self {
+        self.set_firmware_version(firmware_version);
+        self
+    }
+
     /// Gets the [CountryCode].
     pub const fn country_code(&self) -> CountryCode {
         self.country_code
+    }
+
+    /// Sets the [CountryCode].
+    pub fn set_country_code(&mut self, country_code: CountryCode) {
+        self.country_code = country_code;
+    }
+
+    /// Builder function that sets the [CountryCode].
+    pub fn with_country_code(mut self, country_code: CountryCode) -> Self {
+        self.set_country_code(country_code);
+        self
     }
 
     /// Gets the [ValueMultiplier].
@@ -56,9 +104,47 @@ impl DeviceStatus {
         self.value_multiplier
     }
 
+    /// Sets the [ValueMultiplier].
+    pub fn set_value_multiplier(&mut self, value_multiplier: ValueMultiplier) {
+        self.value_multiplier = value_multiplier
+    }
+
+    /// Builder function that sets the [ValueMultiplier].
+    pub fn with_value_multiplier(mut self, value_multiplier: ValueMultiplier) -> Self {
+        self.set_value_multiplier(value_multiplier);
+        self
+    }
+
     /// Gets the [ProtocolVersion].
     pub const fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_version
+    }
+
+    /// Sets the [ProtocolVersion].
+    pub fn set_protocol_version(&mut self, protocol_version: ProtocolVersion) {
+        self.protocol_version = protocol_version;
+    }
+
+    /// Builder function that sets the [ProtocolVersion].
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.set_protocol_version(protocol_version);
+        self
+    }
+
+    /// Gets whether the cashbox is attached.
+    pub const fn cashbox_attached(&self) -> bool {
+        self.cashbox_attached
+    }
+
+    /// Sets whether the cashbox is attached.
+    pub fn set_cashbox_attached(&mut self, cashbox_attached: bool) {
+        self.cashbox_attached = cashbox_attached;
+    }
+
+    /// Builder function that sets whether the cashbox is attached.
+    pub fn with_cashbox_attached(mut self, cashbox_attached: bool) -> Self {
+        self.set_cashbox_attached(cashbox_attached);
+        self
     }
 }
 
@@ -71,6 +157,7 @@ impl From<&SetupRequestResponse> for DeviceStatus {
             country_code: val.country_code(),
             value_multiplier: val.value_multiplier(),
             protocol_version: val.protocol_version().unwrap_or(ProtocolVersion::Reserved),
+            cashbox_attached: false,
         }
     }
 }
@@ -90,6 +177,7 @@ impl From<&UnitDataResponse> for DeviceStatus {
             country_code: val.country_code(),
             value_multiplier: val.value_multiplier(),
             protocol_version: val.protocol_version(),
+            cashbox_attached: false,
         }
     }
 }
@@ -115,3 +203,190 @@ impl fmt::Display for DeviceStatus {
         write!(f, "{o}\"response_status\": \"{status}\", \"unit_type\": {unit_type}, \"firmware_version\": \"{firmware}\", \"country_code\": \"{country_code}\", \"value_multiplier\": {vm}, \"protocol_version\": \"{protocol}\"{c}")
     }
 }
+
+/// Atomic integer representation of the [DeviceStatus].
+///
+/// Useful for instantiating a safe, static global state variable.
+#[repr(C)]
+#[derive(Debug)]
+pub struct AtomicDeviceStatus {
+    status: AtomicU8,
+    unit_type: AtomicU8,
+    firmware_version: AtomicU32,
+    country_code: AtomicU32,
+    value_multiplier: AtomicU32,
+    protocol_version: AtomicU8,
+    cashbox_attached: AtomicBool,
+}
+
+impl AtomicDeviceStatus {
+    /// Creates a new [AtomicDeviceStatus].
+    pub const fn new() -> Self {
+        Self {
+            status: AtomicU8::new(ResponseStatus::Ok.to_u8()),
+            unit_type: AtomicU8::new(0),
+            firmware_version: AtomicU32::new(0),
+            country_code: AtomicU32::new(0),
+            value_multiplier: AtomicU32::new(0),
+            protocol_version: AtomicU8::new(0),
+            cashbox_attached: AtomicBool::new(false),
+        }
+    }
+
+    /// Gets the [ResponseStatus].
+    pub fn response_status(&self) -> ResponseStatus {
+        ResponseStatus::from_u8(self.status.load(Ordering::Relaxed))
+    }
+
+    /// Sets the [ResponseStatus].
+    pub fn set_response_status(&self, status: ResponseStatus) {
+        self.status.store(status.to_u8(), Ordering::SeqCst);
+    }
+
+    /// Builder function that sets the [ResponseStatus].
+    pub fn with_response_status(self, status: ResponseStatus) -> Self {
+        self.set_response_status(status);
+        self
+    }
+
+    /// Gets the [UnitType].
+    pub fn unit_type(&self) -> UnitType {
+        UnitType::from_inner(self.unit_type.load(Ordering::Relaxed))
+    }
+
+    /// Sets the [UnitType].
+    pub fn set_unit_type(&self, unit_type: UnitType) {
+        self.unit_type.store(unit_type.as_inner(), Ordering::SeqCst);
+    }
+
+    /// Builder function that sets the [UnitType].
+    pub fn with_unit_type(self, unit_type: UnitType) -> Self {
+        self.set_unit_type(unit_type);
+        self
+    }
+
+    /// Gets the [FirmwareVersion].
+    pub fn firmware_version(&self) -> FirmwareVersion {
+        FirmwareVersion::from_inner(self.firmware_version.load(Ordering::Relaxed))
+    }
+
+    /// Sets the [FirmwareVersion].
+    pub fn set_firmware_version(&self, firmware_version: FirmwareVersion) {
+        self.firmware_version
+            .store(firmware_version.as_inner(), Ordering::SeqCst);
+    }
+
+    /// Builder function that sets the [FirmwareVersion].
+    pub fn with_firmware_version(self, firmware_version: FirmwareVersion) -> Self {
+        self.set_firmware_version(firmware_version);
+        self
+    }
+
+    /// Gets the [CountryCode].
+    pub fn country_code(&self) -> CountryCode {
+        CountryCode::from_inner(self.country_code.load(Ordering::Relaxed))
+    }
+
+    /// Sets the [CountryCode].
+    pub fn set_country_code(&self, country_code: CountryCode) {
+        self.country_code
+            .store(country_code.as_inner(), Ordering::SeqCst);
+    }
+
+    /// Builder function that sets the [CountryCode].
+    pub fn with_country_code(self, country_code: CountryCode) -> Self {
+        self.set_country_code(country_code);
+        self
+    }
+
+    /// Gets the [ValueMultiplier].
+    pub fn value_multiplier(&self) -> ValueMultiplier {
+        ValueMultiplier::from_inner(self.value_multiplier.load(Ordering::Relaxed))
+    }
+
+    /// Sets the [ValueMultiplier].
+    pub fn set_value_multiplier(&self, value_multiplier: ValueMultiplier) {
+        self.value_multiplier
+            .store(value_multiplier.as_inner(), Ordering::SeqCst);
+    }
+
+    /// Builder function that sets the [ValueMultiplier].
+    pub fn with_value_multiplier(self, value_multiplier: ValueMultiplier) -> Self {
+        self.set_value_multiplier(value_multiplier);
+        self
+    }
+
+    /// Gets the [ProtocolVersion].
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        ProtocolVersion::from_u8(self.protocol_version.load(Ordering::Relaxed))
+    }
+
+    /// Sets the [ProtocolVersion].
+    pub fn set_protocol_version(&self, protocol_version: ProtocolVersion) {
+        self.protocol_version
+            .store(protocol_version.to_u8(), Ordering::SeqCst);
+    }
+
+    /// Builder function that sets the [ProtocolVersion].
+    pub fn with_protocol_version(self, protocol_version: ProtocolVersion) -> Self {
+        self.set_protocol_version(protocol_version);
+        self
+    }
+
+    /// Gets whether the cashbox is attached.
+    pub fn cashbox_attached(&self) -> bool {
+        self.cashbox_attached.load(Ordering::Relaxed)
+    }
+
+    /// Sets whether the cashbox is attached.
+    pub fn set_cashbox_attached(&self, cashbox_attached: bool) {
+        self.cashbox_attached
+            .store(cashbox_attached, Ordering::SeqCst);
+    }
+
+    /// Builder function that sets whether the cashbox is attached.
+    pub fn with_cashbox_attached(self, cashbox_attached: bool) -> Self {
+        self.set_cashbox_attached(cashbox_attached);
+        self
+    }
+}
+
+impl From<&DeviceStatus> for AtomicDeviceStatus {
+    fn from(val: &DeviceStatus) -> Self {
+        Self::new()
+            .with_response_status(val.response_status())
+            .with_unit_type(val.unit_type())
+            .with_firmware_version(val.firmware_version())
+            .with_country_code(val.country_code())
+            .with_value_multiplier(val.value_multiplier())
+            .with_protocol_version(val.protocol_version())
+            .with_cashbox_attached(val.cashbox_attached())
+    }
+}
+
+impl From<DeviceStatus> for AtomicDeviceStatus {
+    fn from(val: DeviceStatus) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<&AtomicDeviceStatus> for DeviceStatus {
+    fn from(val: &AtomicDeviceStatus) -> Self {
+        Self::new()
+            .with_response_status(val.response_status())
+            .with_unit_type(val.unit_type())
+            .with_firmware_version(val.firmware_version())
+            .with_country_code(val.country_code())
+            .with_value_multiplier(val.value_multiplier())
+            .with_protocol_version(val.protocol_version())
+            .with_cashbox_attached(val.cashbox_attached())
+    }
+}
+
+impl From<AtomicDeviceStatus> for DeviceStatus {
+    fn from(val: AtomicDeviceStatus) -> Self {
+        (&val).into()
+    }
+}
+
+impl_default!(AtomicDeviceStatus);

--- a/src/types/events/method.rs
+++ b/src/types/events/method.rs
@@ -339,6 +339,7 @@ impl_default!(Method);
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "jsonrpc")]
     use super::*;
 
     #[cfg(feature = "jsonrpc")]

--- a/src/types/version.rs
+++ b/src/types/version.rs
@@ -2,7 +2,7 @@
 
 use crate::std::{self, fmt};
 
-use crate::tuple_struct_ser;
+use crate::{impl_default, tuple_struct_ser};
 
 /// Protocol version supported by device firmware
 ///
@@ -66,9 +66,17 @@ pub enum ProtocolVersion {
     Reserved = 0xff,
 }
 
-impl From<u8> for ProtocolVersion {
-    fn from(b: u8) -> Self {
-        match b {
+impl ProtocolVersion {
+    /// Creates a new [ProtocolVersion].
+    ///
+    /// Default value is `0x06`, since this seems to be the base protocol for most devices.
+    pub const fn new() -> Self {
+        Self::Six
+    }
+
+    /// Converts a `u8` into a [ProtocolVersion].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
             0x01 => Self::One,
             0x02 => Self::Two,
             0x03 => Self::Three,
@@ -80,11 +88,10 @@ impl From<u8> for ProtocolVersion {
             _ => Self::Reserved,
         }
     }
-}
 
-impl From<ProtocolVersion> for u8 {
-    fn from(p: ProtocolVersion) -> Self {
-        match p {
+    /// Converts a [ProtocolVersion] into a `u8`.
+    pub const fn to_u8(&self) -> u8 {
+        match self {
             ProtocolVersion::One => 0x01,
             ProtocolVersion::Two => 0x02,
             ProtocolVersion::Three => 0x03,
@@ -98,15 +105,27 @@ impl From<ProtocolVersion> for u8 {
     }
 }
 
+impl From<u8> for ProtocolVersion {
+    fn from(val: u8) -> Self {
+        Self::from_u8(val)
+    }
+}
+
+impl From<ProtocolVersion> for u8 {
+    fn from(val: ProtocolVersion) -> Self {
+        val.to_u8()
+    }
+}
+
 impl From<&ProtocolVersion> for u8 {
-    fn from(p: &ProtocolVersion) -> Self {
-        (*p).into()
+    fn from(val: &ProtocolVersion) -> Self {
+        (*val).into()
     }
 }
 
 impl From<ProtocolVersion> for &'static str {
-    fn from(p: ProtocolVersion) -> Self {
-        match p {
+    fn from(val: ProtocolVersion) -> Self {
+        match val {
             ProtocolVersion::One => "1",
             ProtocolVersion::Two => "2",
             ProtocolVersion::Three => "3",
@@ -121,14 +140,8 @@ impl From<ProtocolVersion> for &'static str {
 }
 
 impl From<&ProtocolVersion> for &'static str {
-    fn from(p: &ProtocolVersion) -> Self {
-        (*p).into()
-    }
-}
-
-impl Default for ProtocolVersion {
-    fn default() -> Self {
-        Self::Six
+    fn from(val: &ProtocolVersion) -> Self {
+        (*val).into()
     }
 }
 
@@ -137,6 +150,8 @@ impl fmt::Display for ProtocolVersion {
         write!(f, "{}", <&'static str>::from(self))
     }
 }
+
+impl_default!(ProtocolVersion);
 
 tuple_struct_ser!(
     FirmwareVersion,


### PR DESCRIPTION
Adds `AtomicDeviceStatus` struct to use as a global static variable with interior mutability, by using `Atomic*` types. Converts to/from a regular `DeviceStatus` for serializing/deserializing.

Adds "builder" interface for the `DeviceStatus` struct.