### PR TITLE
fixup/jsonrpc: better parsing for `Request` messages

### DIFF
--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -4,29 +4,105 @@ use alloc::format;
 use smol_jsonrpc::Request;
 
 use super::jsonrpc_id;
+use crate::types::events::*;
 use crate::{Error, Event, EventPayload, Method};
 
 impl From<&Request> for Event {
     fn from(val: &Request) -> Self {
         let method = Method::from(val.method().unwrap_or(""));
 
-        let payload = match val.params::<EventPayload>() {
-            Ok(event) => event,
-            Err(err) => EventPayload::Error(err.into()),
+        let payload = match method {
+            Method::Fail => {
+                let err = match val.params::<Error>() {
+                    Ok(err) => err,
+                    Err(err) => Error::JsonRpc(format!("failed to parse: {err}")),
+                };
+
+                EventPayload::Error(err)
+            }
+            Method::Disable | Method::Stop | Method::Shutdown => EventPayload::DisableEvent(
+                val.params::<DisableEvent>()
+                    .unwrap_or(DisableEvent::default()),
+            ),
+            Method::Enable | Method::Accept => EventPayload::EnableEvent(
+                val.params::<EnableEvent>()
+                    .unwrap_or(EnableEvent::default()),
+            ),
+            Method::Reject => EventPayload::RejectEvent(
+                val.params::<RejectEvent>()
+                    .unwrap_or(RejectEvent::default()),
+            ),
+            Method::Stack => EventPayload::StackEvent(
+                val.params::<StackEvent>().unwrap_or(StackEvent::default()),
+            ),
+            Method::Status => EventPayload::StatusEvent(
+                val.params::<StatusEvent>()
+                    .unwrap_or(StatusEvent::default()),
+            ),
+            Method::CashboxRemoved => EventPayload::CashboxRemovedEvent(
+                val.params::<CashboxRemovedEvent>()
+                    .unwrap_or(CashboxRemovedEvent::default()),
+            ),
+            Method::CashboxReplaced => EventPayload::CashboxReplacedEvent(
+                val.params::<CashboxReplacedEvent>()
+                    .unwrap_or(CashboxReplacedEvent::default()),
+            ),
+            Method::Disabled => EventPayload::DisabledEvent(
+                val.params::<DisabledEvent>()
+                    .unwrap_or(DisabledEvent::default()),
+            ),
+            Method::FraudAttempt => EventPayload::FraudAttemptEvent(
+                val.params::<FraudAttemptEvent>()
+                    .unwrap_or(FraudAttemptEvent::default()),
+            ),
+            Method::NoteClearedFromFront => EventPayload::NoteClearedFromFrontEvent(
+                val.params::<NoteClearedFromFrontEvent>()
+                    .unwrap_or(NoteClearedFromFrontEvent::default()),
+            ),
+            Method::NoteClearedIntoCashbox => EventPayload::NoteClearedIntoCashboxEvent(
+                val.params::<NoteClearedIntoCashboxEvent>()
+                    .unwrap_or(NoteClearedIntoCashboxEvent::default()),
+            ),
+            Method::NoteCredit => EventPayload::NoteCreditEvent(
+                val.params::<NoteCreditEvent>()
+                    .unwrap_or(NoteCreditEvent::default()),
+            ),
+            Method::Read => {
+                EventPayload::ReadEvent(val.params::<ReadEvent>().unwrap_or(ReadEvent::default()))
+            }
+            Method::Rejected => EventPayload::RejectedEvent(
+                val.params::<RejectedEvent>()
+                    .unwrap_or(RejectedEvent::default()),
+            ),
+            Method::Rejecting => EventPayload::RejectingEvent(
+                val.params::<RejectingEvent>()
+                    .unwrap_or(RejectingEvent::default()),
+            ),
+            Method::Reset => EventPayload::ResetEvent(
+                val.params::<ResetEvent>().unwrap_or(ResetEvent::default()),
+            ),
+            Method::Stacked => EventPayload::StackedEvent(
+                val.params::<StackedEvent>()
+                    .unwrap_or(StackedEvent::default()),
+            ),
+            Method::StackerFull => EventPayload::StackerFullEvent(
+                val.params::<StackerFullEvent>()
+                    .unwrap_or(StackerFullEvent::default()),
+            ),
+            Method::Stacking => EventPayload::StackingEvent(
+                val.params::<StackingEvent>()
+                    .unwrap_or(StackingEvent::default()),
+            ),
+            Method::UnsafeJam => EventPayload::UnsafeJamEvent(
+                val.params::<UnsafeJamEvent>()
+                    .unwrap_or(UnsafeJamEvent::default()),
+            ),
+            Method::Reserved(m) => {
+                EventPayload::Error(Error::JsonRpc(format!("reserved method: {m}")))
+            }
         };
 
-        let payload_method = payload.method();
-
-        if method == payload_method {
-            Self::new(method, payload)
-        } else {
-            Self::new(
-                Method::Fail,
-                EventPayload::Error(Error::JsonRpc(format!(
-                    "Invalid event, have: {payload_method}, expect: {method}, payload: {payload}"
-                ))),
-            )
-        }
+        Self::new(method, payload)
     }
 }
 
@@ -41,7 +117,7 @@ impl From<&Event> for Request {
         Request::new()
             .with_id(jsonrpc_id())
             .with_method(val.method().to_str())
-            .with_params(val.payload())
+            .with_params(val.payload().to_json())
     }
 }
 

--- a/src/types/device_status.rs
+++ b/src/types/device_status.rs
@@ -199,8 +199,9 @@ impl fmt::Display for DeviceStatus {
         let country_code = self.country_code();
         let vm = self.value_multiplier();
         let protocol = self.protocol_version();
+        let cashbox = self.cashbox_attached();
 
-        write!(f, "{o}\"response_status\": \"{status}\", \"unit_type\": {unit_type}, \"firmware_version\": \"{firmware}\", \"country_code\": \"{country_code}\", \"value_multiplier\": {vm}, \"protocol_version\": \"{protocol}\"{c}")
+        write!(f, "{o}\"response_status\": \"{status}\", \"unit_type\": {unit_type}, \"firmware_version\": \"{firmware}\", \"country_code\": \"{country_code}\", \"value_multiplier\": {vm}, \"protocol_version\": \"{protocol}\", \"cashbox_attached\": {cashbox}{c}")
     }
 }
 

--- a/src/types/events.rs
+++ b/src/types/events.rs
@@ -104,6 +104,35 @@ impl EventPayload {
             Self::UnsafeJamEvent(_) => UnsafeJamEvent::method(),
         }
     }
+
+    #[cfg(feature = "jsonrpc")]
+    pub fn to_json(&self) -> serde_json::Value {
+        use serde_json::json;
+
+        match self {
+            Self::Error(evt) => json!(evt),
+            Self::DisableEvent(evt) => json!(evt),
+            Self::EnableEvent(evt) => json!(evt),
+            Self::RejectEvent(evt) => json!(evt),
+            Self::StackEvent(evt) => json!(evt),
+            Self::StatusEvent(evt) => json!(evt),
+            Self::CashboxRemovedEvent(evt) => json!(evt),
+            Self::CashboxReplacedEvent(evt) => json!(evt),
+            Self::DisabledEvent(evt) => json!(evt),
+            Self::FraudAttemptEvent(evt) => json!(evt),
+            Self::NoteClearedFromFrontEvent(evt) => json!(evt),
+            Self::NoteClearedIntoCashboxEvent(evt) => json!(evt),
+            Self::NoteCreditEvent(evt) => json!(evt),
+            Self::ReadEvent(evt) => json!(evt),
+            Self::RejectedEvent(evt) => json!(evt),
+            Self::RejectingEvent(evt) => json!(evt),
+            Self::ResetEvent(evt) => json!(evt),
+            Self::StackedEvent(evt) => json!(evt),
+            Self::StackerFullEvent(evt) => json!(evt),
+            Self::StackingEvent(evt) => json!(evt),
+            Self::UnsafeJamEvent(evt) => json!(evt),
+        }
+    }
 }
 
 impl fmt::Display for EventPayload {

--- a/src/types/events/status.rs
+++ b/src/types/events/status.rs
@@ -3,15 +3,15 @@ use crate::{std::fmt, DeviceStatus};
 use super::{Method, CLOSE_BRACE, OPEN_BRACE};
 
 /// Represents a [Status](crate::ResponseStatus::Status) event.
-#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StatusEvent {
-    status: DeviceStatus,
+    details: DeviceStatus,
 }
 
 impl StatusEvent {
     /// Creates a new [StatusEvent].
-    pub const fn new(status: DeviceStatus) -> Self {
-        Self { status }
+    pub const fn new(details: DeviceStatus) -> Self {
+        Self { details }
     }
 
     /// Gets the [Method] for the [StatusEvent].
@@ -26,7 +26,7 @@ impl StatusEvent {
 
     /// Gets a reference to the [DeviceStatus].
     pub const fn device_status(&self) -> &DeviceStatus {
-        &self.status
+        &self.details
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -56,8 +56,21 @@ impl fmt::Display for StatusEvent {
     }
 }
 
-impl Default for StatusEvent {
-    fn default() -> Self {
-        Self::new(DeviceStatus::default())
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "jsonrpc")]
+    use super::*;
+    #[cfg(feature = "jsonrpc")]
+    use crate::Result;
+
+    #[cfg(feature = "jsonrpc")]
+    #[test]
+    fn test_status_event_serde() -> Result<()> {
+        let event = StatusEvent::default();
+        let exp_event_str = "{\"details\":{\"status\":\"Ok\",\"unit_type\":0,\"firmware_version\":0,\"country_code\":0,\"value_multiplier\":0,\"protocol_version\":\"Reserved\",\"cashbox_attached\":false}}";
+
+        assert_eq!(serde_json::to_string(&event)?.as_str(), exp_event_str);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Improves JSON-RPC message parsing for `smol_jsonrpc::Request` messages. Instead of including the method twice in request, use the `method` to determine the `params` type.

Other minor fixes related to parsing improvements.