### PR TITLE
version: bump to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps minor version to v0.3.0, includes the changes to `DeviceStatus`, and the JSON-RPC message parsing.

Because message parsing is changed in a non-backwards-compatible way, the minor version needs to be bumped.