### PR TITLE
version: bump to v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps the minor version to include incompatible changes to encryption (non-functional to functional).