### PR TITLE
encrypted: add byte stuffing

### DIFF
--- a/src/encrypted/command.rs
+++ b/src/encrypted/command.rs
@@ -204,6 +204,10 @@ impl EncryptedCommand {
 
         super::increment_sequence_count();
 
+        if let Err(err) = enc_msg.stuff_encrypted_data() {
+            log::error!("error stuffing encrypted command message: {err}");
+        }
+
         enc_msg
     }
 
@@ -211,9 +215,14 @@ impl EncryptedCommand {
     ///
     /// Converts the [WrappedEncryptedMessage] into an [EncryptedCommand].
     ///
-    /// **Note**: only useful if implmenting a device-side binary.
-    pub fn decrypt(key: &AesKey, message: WrappedEncryptedMessage) -> Self {
+    /// **Note**: only useful if implementing a device-side binary, and/or testing host-side
+    /// functionality.
+    pub fn decrypt(key: &AesKey, mut message: WrappedEncryptedMessage) -> Self {
         use crate::aes;
+
+        if let Err(err) = message.unstuff_encrypted_data() {
+            log::error!("error unstuffing encrypted command message: {err}");
+        }
 
         let mut dec_msg = Self::new();
         dec_msg.set_data_len(message.data_len().saturating_sub(len::ENCRYPTED_METADATA) as u8);

--- a/src/encrypted/wrapped.rs
+++ b/src/encrypted/wrapped.rs
@@ -1,6 +1,6 @@
 use crate::{
     impl_command_display, impl_command_ops, impl_default, impl_message_from_buf, impl_response_ops,
-    impl_wrapped_message_ops, len, CommandOps, MessageOps, MessageType,
+    impl_wrapped_message_ops, len, CommandOps, Error, MessageOps, MessageType, Result,
 };
 
 /// Wrapped Encrypted Message (0x7E)
@@ -33,6 +33,51 @@ impl WrappedEncryptedMessage {
         let end = start + self.data_len() - 1;
 
         self.buf[start..end].as_ref()
+    }
+
+    /// Adds byte stuffing to the encrypted message data to avoid devices thinking we started a new
+    /// packet in the middle of an encrypted packet.
+    pub(crate) fn stuff_encrypted_data(&mut self) -> Result<usize> {
+        use super::stuff;
+        use crate::message::index;
+
+        let start = index::DATA + 1;
+        // end after the CRC data
+        let end = start + self.data_len() + 2;
+
+        stuff(&mut self.buf[start..], end)
+    }
+
+    /// Removes byte stuffing from the encrypted message data.
+    pub(crate) fn unstuff_encrypted_data(&mut self) -> Result<()> {
+        use super::unstuff;
+        use crate::message::{index, STX};
+
+        let start = index::DATA + 1;
+        // end after the CRC data
+        let exp_end = start + self.data_len() + 2;
+        // Because there may be byte stuffing, the actual end of the data is somewhere between the
+        // end of where the CRC should be, and the maximum buffer length.
+        //
+        // This is because stuffed bytes are not added to the `LEN` byte count.
+        let len = self.buf.len();
+        let mut i = start;
+        let mut end = exp_end;
+        while end < len && i < end {
+            if self.buf[i] == STX && self.buf[i + 1] == STX {
+                i += 2;
+                end += 1;
+            } else {
+                i += 1;
+            }
+        }
+
+        let calc_end = unstuff(&mut self.buf[start..], end)?;
+        if calc_end != exp_end {
+            Err(Error::InvalidLength((calc_end, exp_end)))
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
Adds message byte stuffing for encrypted messages.

Byte stuffing is an algorithm to double any `STX(0x7f)` bytes found after the initial byte. The purpose is to avoid devices interpreting the bytes as the start of a new message. Stuffed bytes are not adding to the data length total, and they must be removed before attempting to decrypt a packet. Devices handle this on their own, but the host needs to take care to remove stuffed bytes before attempting decryption.

`EncryptedResponse::decrypt` handles byte unstuffing internally, and `EncryptedCommand::encrypt` handles byte stuffing internally. Users are encouraged to use these methods for encrypted communication.