### PR TITLE
events: add `DispenseEvent`

### DIFF
--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -37,6 +37,10 @@ impl From<&Request> for Event {
                 val.params::<StatusEvent>()
                     .unwrap_or(StatusEvent::default()),
             ),
+            Method::Dispense => EventPayload::DispenseEvent(
+                val.params::<DispenseEvent>()
+                    .unwrap_or(DispenseEvent::new()),
+            ),
             Method::CashboxRemoved => EventPayload::CashboxRemovedEvent(
                 val.params::<CashboxRemovedEvent>()
                     .unwrap_or(CashboxRemovedEvent::new()),

--- a/src/types/events.rs
+++ b/src/types/events.rs
@@ -6,6 +6,7 @@ mod cashbox_removed;
 mod cashbox_replaced;
 mod disable;
 mod disabled;
+mod dispense;
 mod enable;
 mod fraud_attempt;
 mod method;
@@ -28,6 +29,7 @@ pub use cashbox_removed::*;
 pub use cashbox_replaced::*;
 pub use disable::*;
 pub use disabled::*;
+pub use dispense::*;
 pub use enable::*;
 pub use fraud_attempt::*;
 pub use method::*;
@@ -55,6 +57,7 @@ pub enum EventPayload {
     Error(Error),
     // Command event payloads
     DisableEvent(DisableEvent),
+    DispenseEvent(DispenseEvent),
     EnableEvent(EnableEvent),
     RejectEvent(RejectEvent),
     StackEvent(StackEvent),
@@ -83,6 +86,7 @@ impl EventPayload {
         match self {
             Self::Error(_) => Method::Fail,
             Self::DisableEvent(_) => DisableEvent::method(),
+            Self::DispenseEvent(_) => DispenseEvent::method(),
             Self::EnableEvent(_) => EnableEvent::method(),
             Self::RejectEvent(_) => RejectEvent::method(),
             Self::StackEvent(_) => StackEvent::method(),
@@ -112,6 +116,7 @@ impl EventPayload {
         match self {
             Self::Error(evt) => json!(evt),
             Self::DisableEvent(evt) => json!(evt),
+            Self::DispenseEvent(evt) => json!(evt),
             Self::EnableEvent(evt) => json!(evt),
             Self::RejectEvent(evt) => json!(evt),
             Self::StackEvent(evt) => json!(evt),
@@ -140,6 +145,7 @@ impl fmt::Display for EventPayload {
         match self {
             Self::Error(err) => write!(f, r#"{{"error": "{err}"}}"#),
             Self::DisableEvent(evt) => write!(f, "{evt}"),
+            Self::DispenseEvent(evt) => write!(f, "{evt}"),
             Self::EnableEvent(evt) => write!(f, "{evt}"),
             Self::RejectEvent(evt) => write!(f, "{evt}"),
             Self::StackEvent(evt) => write!(f, "{evt}"),
@@ -270,6 +276,7 @@ impl From<Method> for Event {
             Method::Disable | Method::Stop | Method::Shutdown => {
                 EventPayload::DisableEvent(DisableEvent::new())
             }
+            Method::Dispense => EventPayload::DispenseEvent(DispenseEvent::default()),
             Method::Enable | Method::Accept => EventPayload::EnableEvent(EnableEvent::default()),
             Method::Reject => EventPayload::RejectEvent(RejectEvent::new()),
             Method::Stack => EventPayload::StackEvent(StackEvent::default()),

--- a/src/types/events.rs
+++ b/src/types/events.rs
@@ -48,9 +48,6 @@ pub use stacking::*;
 pub use status::*;
 pub use unsafe_jam::*;
 
-pub const OPEN_BRACE: &str = "{";
-pub const CLOSE_BRACE: &str = "}";
-
 /// JSON-RPC payloads for request parameters and response results.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum EventPayload {

--- a/src/types/events/cashbox_removed.rs
+++ b/src/types/events/cashbox_removed.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [CashboxRemoved](crate::ResponseStatus::CashboxRemoved) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl CashboxRemovedEvent {
     /// Gets the [Method] for the [CashboxRemovedEvent].
     pub const fn method() -> Method {
         Method::CashboxRemoved
+    }
+
+    /// Converts the [CashboxRemovedEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for CashboxRemovedEvent {
     }
 }
 
+impl From<&CashboxRemovedEvent> for &'static str {
+    fn from(val: &CashboxRemovedEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<CashboxRemovedEvent> for &'static str {
+    fn from(val: CashboxRemovedEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for CashboxRemovedEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/cashbox_replaced.rs
+++ b/src/types/events/cashbox_replaced.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [CashboxReplaced](crate::ResponseStatus::CashboxReplaced) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl CashboxReplacedEvent {
     /// Gets the [Method] for the [CashboxReplacedEvent].
     pub const fn method() -> Method {
         Method::CashboxReplaced
+    }
+
+    /// Converts the [CashboxReplacedEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -57,13 +62,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for CashboxReplacedEvent {
     }
 }
 
+impl From<&CashboxReplacedEvent> for &'static str {
+    fn from(val: &CashboxReplacedEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<CashboxReplacedEvent> for &'static str {
+    fn from(val: CashboxReplacedEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for CashboxReplacedEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/disable.rs
+++ b/src/types/events/disable.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Disable](crate::ResponseDisable::Disable) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -42,7 +42,7 @@ impl From<DisableEvent> for &'static str {
 
 impl fmt::Display for DisableEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}", self.to_str())
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/disabled.rs
+++ b/src/types/events/disabled.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Disabled](crate::ResponseStatus::Disabled) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl DisabledEvent {
     /// Gets the [Method] for the [DisabledEvent].
     pub const fn method() -> Method {
         Method::Disabled
+    }
+
+    /// Converts the [DisabledEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -56,11 +61,7 @@ impl<const N: usize> TryFrom<&[u8; N]> for DisabledEvent {
 
 impl fmt::Display for DisabledEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/dispense.rs
+++ b/src/types/events/dispense.rs
@@ -1,0 +1,69 @@
+use crate::{impl_default, std::fmt, PayoutDenominationList};
+
+use super::Method;
+
+/// Represents a [Dispense](crate::PayoutDenominationCommand) event.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DispenseEvent(PayoutDenominationList);
+
+impl DispenseEvent {
+    /// Creates a new [DispenseEvent].
+    pub const fn new() -> Self {
+        Self(PayoutDenominationList::new())
+    }
+
+    /// Creates a new [DispenseEvent] with the provided parameter.
+    pub const fn create(list: PayoutDenominationList) -> Self {
+        Self(list)
+    }
+
+    /// Gets the [Method] for the [DispenseEvent].
+    pub const fn method() -> Method {
+        Method::Dispense
+    }
+
+    /// Converts the [DispenseEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
+    }
+
+    /// Gets the length of the event in a [PollResponse](crate::PollResponse).
+    pub const fn len() -> usize {
+        1
+    }
+
+    /// Gets a reference to the inner representation of the [DispenseEvent].
+    pub const fn as_inner(&self) -> &PayoutDenominationList {
+        &self.0
+    }
+
+    /// Gets a mutable reference to the inner representation of the [DispenseEvent].
+    pub fn as_inner_mut(&mut self) -> &mut PayoutDenominationList {
+        &mut self.0
+    }
+
+    /// Consumes the [DispenseEvent], returning its inner repreesentation.
+    pub fn to_inner(self) -> PayoutDenominationList {
+        self.0
+    }
+}
+
+impl From<&DispenseEvent> for &'static str {
+    fn from(val: &DispenseEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<DispenseEvent> for &'static str {
+    fn from(val: DispenseEvent) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for DispenseEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#"{{"{}"}}"#, self.to_str())
+    }
+}
+
+impl_default!(DispenseEvent);

--- a/src/types/events/enable.rs
+++ b/src/types/events/enable.rs
@@ -1,6 +1,6 @@
 use crate::{std::fmt, ProtocolVersion};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Enable](crate::ResponseEnable::Enable) event.
 #[derive(Clone, Copy, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -66,11 +66,9 @@ impl From<&ProtocolVersion> for EnableEvent {
 
 impl fmt::Display for EnableEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (o, c) = (OPEN_BRACE, CLOSE_BRACE);
-
         let method = self.to_str();
         let protocol = self.protocol_version();
 
-        write!(f, "{o}\"{method}\": {o}\"protocol_version\": {protocol}{c}")
+        write!(f, r#"{{"{method}": {{"protocol_version": {protocol}}}"#)
     }
 }

--- a/src/types/events/fraud_attempt.rs
+++ b/src/types/events/fraud_attempt.rs
@@ -1,6 +1,6 @@
 use crate::{channel_value, std::fmt, ChannelValue, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [FraudAttempt](crate::ResponseStatus::FraudAttempt) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -17,6 +17,11 @@ impl FraudAttemptEvent {
     /// Gets the [Method] for the [FraudAttemptEvent].
     pub const fn method() -> Method {
         Method::FraudAttempt
+    }
+
+    /// Converts the [FraudAttemptEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the [ChannelValue].
@@ -77,13 +82,21 @@ impl From<&ChannelValue> for FraudAttemptEvent {
     }
 }
 
+impl From<&FraudAttemptEvent> for &'static str {
+    fn from(val: &FraudAttemptEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<FraudAttemptEvent> for &'static str {
+    fn from(val: FraudAttemptEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for FraudAttemptEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/method.rs
+++ b/src/types/events/method.rs
@@ -25,6 +25,8 @@ pub enum Method {
     Status,
     /// Shutdown the server.
     Shutdown,
+    /// Dispense notes from the device.
+    Dispense,
     /// Cashbox removed from device.
     CashboxRemoved = ResponseStatus::CashboxRemoved.to_u8(),
     /// Cashbox replaced into device.
@@ -78,6 +80,7 @@ impl Method {
             Self::Reject => "reject",
             Self::Stack => "stack",
             Self::Shutdown => "shutdown",
+            Self::Dispense => "dispense",
             Self::CashboxRemoved => "cashbox_removed",
             Self::CashboxReplaced => "cashbox_replaced",
             Self::Disabled => "disabled",
@@ -171,6 +174,7 @@ impl FromStr for Method {
             "reject" => Self::Reject,
             "stack" => Self::Stack,
             "shutdown" => Self::Shutdown,
+            "dispense" => Self::Dispense,
             "cashbox_removed" => Self::CashboxRemoved,
             "cashbox_replaced" => Self::CashboxReplaced,
             "disabled" => Self::Disabled,
@@ -280,6 +284,7 @@ impl serde::Serialize for Method {
             Self::Stack => serializer.serialize_unit_variant("Method", 5, "stack"),
             Self::Status => serializer.serialize_unit_variant("Method", 6, "status"),
             Self::Shutdown => serializer.serialize_unit_variant("Method", 7, "shutdown"),
+            Self::Dispense => serializer.serialize_unit_variant("Method", 7, "dispense"),
             Self::CashboxRemoved => {
                 serializer.serialize_unit_variant("Method", 8, "cashbox_removed")
             }

--- a/src/types/events/note_cleared_from_front.rs
+++ b/src/types/events/note_cleared_from_front.rs
@@ -1,6 +1,6 @@
 use crate::{channel_value, std::fmt, ChannelValue, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [NoteClearedFromFront](crate::ResponseStatus::NoteClearedFromFront) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -87,14 +87,24 @@ impl From<&ChannelValue> for NoteClearedFromFrontEvent {
     }
 }
 
+impl From<&NoteClearedFromFrontEvent> for &'static str {
+    fn from(val: &NoteClearedFromFrontEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<NoteClearedFromFrontEvent> for &'static str {
+    fn from(val: NoteClearedFromFrontEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for NoteClearedFromFrontEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (o, c) = (OPEN_BRACE, CLOSE_BRACE);
-
         let method = self.to_str();
         let value = self.value();
 
-        write!(f, "{o}\"{method}\": {o}\"value\": {value}{c}{c}")
+        write!(f, r#"{{"{method}": {{"value": {value}}}}}"#)
     }
 }
 

--- a/src/types/events/note_cleared_into_cashbox.rs
+++ b/src/types/events/note_cleared_into_cashbox.rs
@@ -1,6 +1,6 @@
 use crate::{channel_value, std::fmt, ChannelValue, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [NoteClearedIntoCashbox](crate::ResponseStatus::NoteClearedIntoCashbox) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -87,14 +87,24 @@ impl From<&ChannelValue> for NoteClearedIntoCashboxEvent {
     }
 }
 
+impl From<&NoteClearedIntoCashboxEvent> for &'static str {
+    fn from(val: &NoteClearedIntoCashboxEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<NoteClearedIntoCashboxEvent> for &'static str {
+    fn from(val: NoteClearedIntoCashboxEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for NoteClearedIntoCashboxEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (o, c) = (OPEN_BRACE, CLOSE_BRACE);
-
         let method = self.to_str();
         let value = self.value();
 
-        write!(f, "{o}\"{method}\": {o}\"value\": {value}{c}{c}")
+        write!(f, r#"{{"{method}": {{"value": {value}}}}}"#)
     }
 }
 

--- a/src/types/events/note_credit.rs
+++ b/src/types/events/note_credit.rs
@@ -1,6 +1,6 @@
 use crate::{channel_value, std::fmt, ChannelValue, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [NoteCredit](crate::ResponseStatus::NoteCredit) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -82,14 +82,24 @@ impl From<&ChannelValue> for NoteCreditEvent {
     }
 }
 
+impl From<&NoteCreditEvent> for &'static str {
+    fn from(val: &NoteCreditEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<NoteCreditEvent> for &'static str {
+    fn from(val: NoteCreditEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for NoteCreditEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (o, c) = (OPEN_BRACE, CLOSE_BRACE);
-
         let method = self.to_str();
         let value = self.value();
 
-        write!(f, "{o}\"{method}\": {o}\"value\": {value}{c}{c}")
+        write!(f, r#"{{"{method}": {{"value": {value}}}}}"#)
     }
 }
 

--- a/src/types/events/read.rs
+++ b/src/types/events/read.rs
@@ -1,6 +1,6 @@
 use crate::{channel_value, std::fmt, ChannelValue, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Read](crate::ResponseStatus::Read) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -86,14 +86,24 @@ impl From<&ChannelValue> for ReadEvent {
     }
 }
 
+impl From<&ReadEvent> for &'static str {
+    fn from(val: &ReadEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<ReadEvent> for &'static str {
+    fn from(val: ReadEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for ReadEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (o, c) = (OPEN_BRACE, CLOSE_BRACE);
-
         let method = self.to_str();
         let value = self.value();
 
-        write!(f, "{o}\"{method}\": {o}\"value\": {value}{c}{c}",)
+        write!(f, r#"{{"{method}": {{"value": {value}}}}}"#)
     }
 }
 

--- a/src/types/events/reject.rs
+++ b/src/types/events/reject.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Reject](crate::Method::Reject) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -42,7 +42,7 @@ impl From<RejectEvent> for &'static str {
 
 impl fmt::Display for RejectEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}", self.to_str())
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/rejected.rs
+++ b/src/types/events/rejected.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Rejected](crate::ResponseStatus::Rejected) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl RejectedEvent {
     /// Gets the [Method] for the [RejectedEvent].
     pub const fn method() -> Method {
         Method::Rejected
+    }
+
+    /// Converts the [RejectedEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for RejectedEvent {
     }
 }
 
+impl From<&RejectedEvent> for &'static str {
+    fn from(val: &RejectedEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<RejectedEvent> for &'static str {
+    fn from(val: RejectedEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for RejectedEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/rejecting.rs
+++ b/src/types/events/rejecting.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Rejecting](crate::ResponseStatus::Rejecting) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl RejectingEvent {
     /// Gets the [Method] for the [RejectingEvent].
     pub const fn method() -> Method {
         Method::Rejecting
+    }
+
+    /// Converts the [RejectingEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for RejectingEvent {
     }
 }
 
+impl From<&RejectingEvent> for &'static str {
+    fn from(val: &RejectingEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<RejectingEvent> for &'static str {
+    fn from(val: RejectingEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for RejectingEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/reset.rs
+++ b/src/types/events/reset.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Reset](crate::ResponseStatus::Reset) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl ResetEvent {
     /// Gets the [Method] for the [ResetEvent].
     pub const fn method() -> Method {
         Method::Reset
+    }
+
+    /// Converts the [ResetEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for ResetEvent {
     }
 }
 
+impl From<&ResetEvent> for &'static str {
+    fn from(val: &ResetEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<ResetEvent> for &'static str {
+    fn from(val: ResetEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for ResetEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/stack.rs
+++ b/src/types/events/stack.rs
@@ -1,6 +1,6 @@
 use crate::{std::fmt, ChannelValue};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Stack](crate::Method::Stack) event.
 #[derive(Clone, Copy, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -61,11 +61,9 @@ impl From<&ChannelValue> for StackEvent {
 
 impl fmt::Display for StackEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (o, c) = (OPEN_BRACE, CLOSE_BRACE);
-
         let method = self.to_str();
         let value = self.value();
 
-        write!(f, "{o}\"{method}\": {o}\"value\": {value}{c}{c}")
+        write!(f, r#"{{"{method}": {{"value": {value}}}}}"#)
     }
 }

--- a/src/types/events/stacked.rs
+++ b/src/types/events/stacked.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Stacked](crate::ResponseStatus::Stacked) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl StackedEvent {
     /// Gets the [Method] for the [StackedEvent].
     pub const fn method() -> Method {
         Method::Stacked
+    }
+
+    /// Converts the [StackedEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for StackedEvent {
     }
 }
 
+impl From<&StackedEvent> for &'static str {
+    fn from(val: &StackedEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<StackedEvent> for &'static str {
+    fn from(val: StackedEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for StackedEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/stacker_full.rs
+++ b/src/types/events/stacker_full.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [StackerFull](crate::ResponseStatus::StackerFull) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl StackerFullEvent {
     /// Gets the [Method] for the [StackerFullEvent].
     pub const fn method() -> Method {
         Method::StackerFull
+    }
+
+    /// Converts the [StackerFullEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for StackerFullEvent {
     }
 }
 
+impl From<&StackerFullEvent> for &'static str {
+    fn from(val: &StackerFullEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<StackerFullEvent> for &'static str {
+    fn from(val: StackerFullEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for StackerFullEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/stacking.rs
+++ b/src/types/events/stacking.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [Stacking](crate::ResponseStatus::Stacking) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl StackingEvent {
     /// Gets the [Method] for the [StackingEvent].
     pub const fn method() -> Method {
         Method::Stacking
+    }
+
+    /// Converts the [StackingEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for StackingEvent {
     }
 }
 
+impl From<&StackingEvent> for &'static str {
+    fn from(val: &StackingEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<StackingEvent> for &'static str {
+    fn from(val: StackingEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for StackingEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/events/unsafe_jam.rs
+++ b/src/types/events/unsafe_jam.rs
@@ -1,6 +1,6 @@
 use crate::{impl_default, std::fmt, Error, ResponseStatus, Result};
 
-use super::{Method, CLOSE_BRACE, OPEN_BRACE};
+use super::Method;
 
 /// Represents a [UnsafeJam](crate::ResponseStatus::UnsafeJam) event.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -15,6 +15,11 @@ impl UnsafeJamEvent {
     /// Gets the [Method] for the [UnsafeJamEvent].
     pub const fn method() -> Method {
         Method::UnsafeJam
+    }
+
+    /// Converts the [UnsafeJamEvent] to a string.
+    pub const fn to_str(&self) -> &'static str {
+        Self::method().to_str()
     }
 
     /// Gets the length of the event in a [PollResponse](crate::PollResponse).
@@ -54,13 +59,21 @@ impl<const N: usize> TryFrom<&[u8; N]> for UnsafeJamEvent {
     }
 }
 
+impl From<&UnsafeJamEvent> for &'static str {
+    fn from(val: &UnsafeJamEvent) -> Self {
+        val.to_str()
+    }
+}
+
+impl From<UnsafeJamEvent> for &'static str {
+    fn from(val: UnsafeJamEvent) -> Self {
+        (&val).into()
+    }
+}
+
 impl fmt::Display for UnsafeJamEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{OPEN_BRACE}\"{}\"{CLOSE_BRACE}",
-            Self::method().to_str()
-        )
+        write!(f, r#"{{"{}"}}"#, self.to_str())
     }
 }
 

--- a/src/types/payout_denomination/list.rs
+++ b/src/types/payout_denomination/list.rs
@@ -21,7 +21,7 @@ pub struct PayoutDenominationList {
 
 impl PayoutDenominationList {
     /// Creates a new empty list.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             denominations: PayoutVec::new(),
         }


### PR DESCRIPTION
Adds the `DispenseEvent` and related payload to handle requests to dispense notes from the device.

Minor fixes for better code style around displaying event types.