### PR TITLE
events: add the accessors for `EventPayload`

### DIFF
--- a/src/encrypted/command.rs
+++ b/src/encrypted/command.rs
@@ -203,6 +203,7 @@ impl EncryptedCommand {
         }
 
         super::increment_sequence_count();
+        log::trace!("encryption sequence count: {}", super::sequence_count());
 
         if let Err(err) = enc_msg.stuff_encrypted_data() {
             log::error!("error stuffing encrypted command message: {err}");

--- a/src/encrypted/response.rs
+++ b/src/encrypted/response.rs
@@ -234,6 +234,7 @@ impl EncryptedResponse {
         }
 
         super::increment_sequence_count();
+        log::trace!("decryption sequence count: {}", super::sequence_count());
 
         dec_msg
     }

--- a/src/encrypted/wrapped.rs
+++ b/src/encrypted/wrapped.rs
@@ -25,6 +25,11 @@ impl WrappedEncryptedMessage {
         msg
     }
 
+    pub fn is_encrypted(&self) -> bool {
+        use crate::message::STEX;
+        self.data()[0] == STEX
+    }
+
     /// Gets the wrapped encrypted data.
     pub fn encrypted_data(&self) -> &[u8] {
         use crate::message::index;

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     Timeout(String),
     #[cfg(feature = "jsonrpc")]
     JsonRpc(String),
+    Event(String),
+    Enum(String),
 }
 
 impl fmt::Display for Error {
@@ -93,6 +95,8 @@ impl fmt::Display for Error {
             Error::Utf8(err) => write!(f, "UTF8 error occurred: {err}"),
             #[cfg(feature = "jsonrpc")]
             Error::JsonRpc(err) => write!(f, "Failed processing JSON-RPC message(s): {err}"),
+            Error::Event(err) => write!(f, "Failed processing event message(s): {err}"),
+            Error::Enum(err) => write!(f, "Enum error: {err}"),
         }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -236,8 +236,6 @@ pub trait MessageOps {
             }
         }
 
-        log::trace!("message type: {msg_type}, buffer: {buf:x?}");
-
         buf_len = std::cmp::min(buf_len, buf_data_len + METADATA);
         let buf_crc = u16::from_le_bytes(buf[buf_len - 2..].try_into().unwrap());
         let exp_crc = crc16(buf[index::SEQ_ID..buf_len - 2].as_ref());

--- a/src/types/encryption/count.rs
+++ b/src/types/encryption/count.rs
@@ -1,4 +1,4 @@
-use crate::tuple_struct;
+use crate::{std::fmt, tuple_struct};
 
 tuple_struct!(
     SequenceCount,
@@ -36,5 +36,11 @@ impl<const N: usize> From<[u8; N]> for SequenceCount {
 impl<const N: usize> From<&[u8; N]> for SequenceCount {
     fn from(val: &[u8; N]) -> Self {
         val.as_ref().into()
+    }
+}
+
+impl fmt::Display for SequenceCount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_inner())
     }
 }

--- a/src/types/events.rs
+++ b/src/types/events.rs
@@ -1,6 +1,6 @@
 //! Event types for polling responses.
 
-use crate::{std::fmt, Error};
+use crate::{inner_enum, std::fmt, Error};
 
 mod cashbox_removed;
 mod cashbox_replaced;
@@ -166,6 +166,41 @@ impl fmt::Display for EventPayload {
     }
 }
 
+inner_enum!(EventPayload, Error, as_error);
+inner_enum!(EventPayload, DisableEvent, as_disable_event);
+inner_enum!(EventPayload, DispenseEvent, as_dispense_event);
+inner_enum!(EventPayload, EnableEvent, as_enable_event);
+inner_enum!(EventPayload, RejectEvent, as_reject_event);
+inner_enum!(EventPayload, StackEvent, as_stack_event);
+inner_enum!(EventPayload, StatusEvent, as_status_event);
+inner_enum!(EventPayload, CashboxRemovedEvent, as_cashbox_removed_event);
+inner_enum!(
+    EventPayload,
+    CashboxReplacedEvent,
+    as_cashbox_replaced_event
+);
+inner_enum!(EventPayload, DisabledEvent, as_disabled_event);
+inner_enum!(EventPayload, FraudAttemptEvent, as_fraud_attempt_event);
+inner_enum!(
+    EventPayload,
+    NoteClearedFromFrontEvent,
+    as_note_cleared_from_front_event
+);
+inner_enum!(
+    EventPayload,
+    NoteClearedIntoCashboxEvent,
+    as_note_cleared_into_cashbox_event
+);
+inner_enum!(EventPayload, NoteCreditEvent, as_note_credit_event);
+inner_enum!(EventPayload, ReadEvent, as_read_event);
+inner_enum!(EventPayload, RejectedEvent, as_rejected_event);
+inner_enum!(EventPayload, RejectingEvent, as_rejecting_event);
+inner_enum!(EventPayload, ResetEvent, as_reset_event);
+inner_enum!(EventPayload, StackedEvent, as_stacked_event);
+inner_enum!(EventPayload, StackerFullEvent, as_stacker_full_event);
+inner_enum!(EventPayload, StackingEvent, as_stacking_event);
+inner_enum!(EventPayload, UnsafeJamEvent, as_unsafe_jam_event);
+
 macro_rules! from_event_for_payload {
     ($event:ident) => {
         impl From<$event> for EventPayload {
@@ -210,6 +245,7 @@ from_event_for_payload!(EnableEvent);
 from_event_for_payload!(RejectEvent);
 from_event_for_payload!(StackEvent);
 from_event_for_payload!(StatusEvent);
+from_event_for_payload!(DispenseEvent);
 // Response events
 from_event_for_payload!(CashboxRemovedEvent);
 from_event_for_payload!(CashboxReplacedEvent);
@@ -353,6 +389,7 @@ from_event_for_event!(EnableEvent);
 from_event_for_event!(RejectEvent);
 from_event_for_event!(StackEvent);
 from_event_for_event!(StatusEvent);
+from_event_for_event!(DispenseEvent);
 // Response events
 from_event_for_event!(CashboxRemovedEvent);
 from_event_for_event!(CashboxReplacedEvent);

--- a/src/types/events/method.rs
+++ b/src/types/events/method.rs
@@ -174,7 +174,7 @@ impl FromStr for Method {
             "reject" => Self::Reject,
             "stack" => Self::Stack,
             "shutdown" => Self::Shutdown,
-            "dispense" => Self::Dispense,
+            "dispense" | "denomination_dispense" => Self::Dispense,
             "cashbox_removed" => Self::CashboxRemoved,
             "cashbox_replaced" => Self::CashboxReplaced,
             "disabled" => Self::Disabled,
@@ -284,31 +284,31 @@ impl serde::Serialize for Method {
             Self::Stack => serializer.serialize_unit_variant("Method", 5, "stack"),
             Self::Status => serializer.serialize_unit_variant("Method", 6, "status"),
             Self::Shutdown => serializer.serialize_unit_variant("Method", 7, "shutdown"),
-            Self::Dispense => serializer.serialize_unit_variant("Method", 7, "dispense"),
+            Self::Dispense => serializer.serialize_unit_variant("Method", 8, "dispense"),
             Self::CashboxRemoved => {
-                serializer.serialize_unit_variant("Method", 8, "cashbox_removed")
+                serializer.serialize_unit_variant("Method", 9, "cashbox_removed")
             }
             Self::CashboxReplaced => {
-                serializer.serialize_unit_variant("Method", 9, "cashbox_replaced")
+                serializer.serialize_unit_variant("Method", 10, "cashbox_replaced")
             }
-            Self::Disabled => serializer.serialize_unit_variant("Method", 10, "disabled"),
-            Self::FraudAttempt => serializer.serialize_unit_variant("Method", 11, "fraud_attempt"),
+            Self::Disabled => serializer.serialize_unit_variant("Method", 11, "disabled"),
+            Self::FraudAttempt => serializer.serialize_unit_variant("Method", 12, "fraud_attempt"),
             Self::NoteClearedFromFront => {
-                serializer.serialize_unit_variant("Method", 12, "note_cleared_return")
+                serializer.serialize_unit_variant("Method", 13, "note_cleared_return")
             }
             Self::NoteClearedIntoCashbox => {
-                serializer.serialize_unit_variant("Method", 13, "note_cleared_stack")
+                serializer.serialize_unit_variant("Method", 14, "note_cleared_stack")
             }
-            Self::NoteCredit => serializer.serialize_unit_variant("Method", 14, "note_credit"),
-            Self::Read => serializer.serialize_unit_variant("Method", 15, "cash_insertion"),
-            Self::Rejected => serializer.serialize_unit_variant("Method", 16, "rejected"),
-            Self::Rejecting => serializer.serialize_unit_variant("Method", 17, "rejecting"),
-            Self::Reset => serializer.serialize_unit_variant("Method", 18, "reset"),
-            Self::Stacked => serializer.serialize_unit_variant("Method", 19, "stacked"),
-            Self::StackerFull => serializer.serialize_unit_variant("Method", 20, "stacker_full"),
-            Self::Stacking => serializer.serialize_unit_variant("Method", 21, "stacking"),
-            Self::UnsafeJam => serializer.serialize_unit_variant("Method", 22, "unsafe_jam"),
-            Self::Fail => serializer.serialize_unit_variant("Method", 23, "fail"),
+            Self::NoteCredit => serializer.serialize_unit_variant("Method", 15, "note_credit"),
+            Self::Read => serializer.serialize_unit_variant("Method", 16, "cash_insertion"),
+            Self::Rejected => serializer.serialize_unit_variant("Method", 17, "rejected"),
+            Self::Rejecting => serializer.serialize_unit_variant("Method", 18, "rejecting"),
+            Self::Reset => serializer.serialize_unit_variant("Method", 19, "reset"),
+            Self::Stacked => serializer.serialize_unit_variant("Method", 20, "stacked"),
+            Self::StackerFull => serializer.serialize_unit_variant("Method", 21, "stacker_full"),
+            Self::Stacking => serializer.serialize_unit_variant("Method", 22, "stacking"),
+            Self::UnsafeJam => serializer.serialize_unit_variant("Method", 23, "unsafe_jam"),
+            Self::Fail => serializer.serialize_unit_variant("Method", 24, "fail"),
             Self::Reserved(_) => serializer.serialize_unit_variant("Method", 0xff, "reserved"),
         }
     }


### PR DESCRIPTION
Adds accessor functions to retrieve the inner type of new-type enum variants.

Applies the new macro to the `EventPayload` enum, to allow users to retrieve a reference to the inner type of each variant.

Other minor fixes for code health.