### PR TITLE
version: bump to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps the release version to `0.4.2` to include the added `PayoutByDenomination` message and other changes.