### PR TITLE
version: bump to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps the minor version to include backward-incompatible changes for encryption mode.