### PR TITLE
fixup/payout: various fixes for payout functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"

--- a/src/payout_by_denomination/command.rs
+++ b/src/payout_by_denomination/command.rs
@@ -55,6 +55,7 @@ impl PayoutByDenominationCommand {
     pub fn set_number_of_payouts(&mut self, num: u8) {
         if (0..=MAX_PAYOUTS).contains(&(num as usize)) {
             self.buf[index::NUMBER_BLOCKS] = num;
+            self.set_data_len(num.saturating_mul(PAYOUT_BLOCK as u8).saturating_add(2));
         }
     }
 

--- a/src/types/payout_denomination/list.rs
+++ b/src/types/payout_denomination/list.rs
@@ -27,6 +27,11 @@ impl PayoutDenominationList {
         }
     }
 
+    /// Creates a new [PayoutDenominationList] from the provided [PayoutDenomination]s.
+    pub const fn create(denominations: PayoutVec) -> Self {
+        Self { denominations }
+    }
+
     /// Gets an iterator over the list.
     pub fn iter(&self) -> slice::Iter<PayoutDenomination> {
         self.denominations.iter()


### PR DESCRIPTION
Converts a `&str` to lowercase before attempting to convert to a `Method`. Improves handling JSON-RPC clients that send uppercase versions of supported `Method` strings.

Automatically sets the data length when setting a valid `PayoutDenominationList` in a `PayoutByDenominationCommand`.

Fixes an error where the data length is not properly set, and the message is incorrectly serialized over the wire.

Adds a constructor to create a `PayoutDenominationList` from a list of `PayoutDenomination`s.

Bumps the release version to include changes for payout functionality.