### PR TITLE
fixup: encrypted message data length check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"

--- a/src/encrypted/response.rs
+++ b/src/encrypted/response.rs
@@ -7,7 +7,8 @@ use crate::seed;
 
 use crate::{
     impl_default, impl_encrypted_message_ops, impl_message_from_buf, impl_response_display,
-    impl_response_ops, len, AesKey, Error, MessageOps, ResponseOps, Result, SequenceCount,
+    impl_response_ops, len, std::cmp, AesKey, Error, MessageOps, ResponseOps, Result,
+    SequenceCount,
 };
 
 use super::{encrypted_index as index, WrappedEncryptedMessage};
@@ -175,7 +176,7 @@ impl EncryptedResponse {
     }
 
     fn encrypt_data(&mut self) -> &mut [u8] {
-        let len = self.len();
+        let len = cmp::min(self.len(), len::MAX_ENCRYPTED_DATA);
         self.buf[index::LEN..len].as_mut()
     }
 

--- a/src/payout_by_denomination/command.rs
+++ b/src/payout_by_denomination/command.rs
@@ -162,8 +162,7 @@ impl fmt::Display for PayoutByDenominationCommand {
         write!(
             f,
             "Payout denominations: {} | ",
-            self.payout_denominations()
-                .unwrap_or(PayoutDenominationList::new())
+            self.payout_denominations().unwrap_or_default()
         )?;
         write!(f, "Payout option: {} | ", self.payout_option())?;
         write!(f, "CRC-16: 0x{:04x}", self.checksum())


### PR DESCRIPTION
Prevents a panic by taking the minimum of the set data length and `len::MAX_ENCRYPTED_DATA`. Some device-sent messages may be sent when encrypted mode is enabled, but are not actually well-formatted encrypted messages.

Bumps the patch release version to include the fixes for encrypted message data length check.