### PR TITLE
version: bump to v0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Messages and related types for implementing the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps the patch release version to `v0.5.4` to include firmware download types, and other minor fixes.